### PR TITLE
[Feature] Support Business Logic level dependency conditions

### DIFF
--- a/lib/generators/surveyor/migrations_generator.rb
+++ b/lib/generators/surveyor/migrations_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators/active_record'
 
 class Surveyor::MigrationsGenerator < Rails::Generators::Base
   include Rails::Generators::Migration
-  
+
   source_root File.expand_path('../templates', __FILE__)
   desc 'Instal Surveyor migrations'
 
@@ -36,6 +36,7 @@ class Surveyor::MigrationsGenerator < Rails::Generators::Base
     api_ids_must_be_unique
     create_survey_translations
     add_input_mask_attributes_to_answer
+    add_condition_type_fields_to_dependency_conditions
   )
 
   def install
@@ -47,7 +48,7 @@ class Surveyor::MigrationsGenerator < Rails::Generators::Base
       )
     end
   end
-  
+
   def self.next_migration_number(dirname)
     ActiveRecord::Generators::Base.next_migration_number(dirname)
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_condition_type_fields_to_dependency_conditions.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_condition_type_fields_to_dependency_conditions.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+class AddConditionTypeFieldsToDependencyConditions < ActiveRecord::Migration<%= migration_version %>
+  def self.up
+    add_column :surveyor_dependency_conditions, :condition_type, :string, default: 'default'
+    add_column :surveyor_dependency_conditions, :logic_reference, :string
+  end
+
+  def self.down
+    remove_column :surveyor_dependency_conditions, :condition_type
+    remove_column :surveyor_dependency_conditions, :logic_reference
+  end
+end

--- a/lib/surveyor/permitted_params.rb
+++ b/lib/surveyor/permitted_params.rb
@@ -66,7 +66,7 @@ module Surveyor
       strong_parameters.permit(*dependency_condition_attributes)
     end
     def dependency_condition_attributes
-      [:dependency, :question, :answer, :dependency_id, :rule_key, :question_id, :operator, :answer_id, :datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :question_reference, :answer_reference]
+      [:dependency, :question, :answer, :dependency_id, :rule_key, :question_id, :operator, :answer_id, :datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :question_reference, :answer_reference, :condition_type, :logic_reference]
     end
 
     # validation

--- a/lib/surveyor/version.rb
+++ b/lib/surveyor/version.rb
@@ -1,3 +1,3 @@
 module Surveyor
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/dummies/dummy5.1/db/migrate/20220419032428_add_condition_type_fields_to_dependency_conditions.rb
+++ b/spec/dummies/dummy5.1/db/migrate/20220419032428_add_condition_type_fields_to_dependency_conditions.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+class AddConditionTypeFieldsToDependencyConditions < ActiveRecord::Migration[5.1]
+  def self.up
+    add_column :surveyor_dependency_conditions, :condition_type, :string, default: 'default'
+    add_column :surveyor_dependency_conditions, :logic_reference, :string
+  end
+
+  def self.down
+    remove_column :surveyor_dependency_conditions, :condition_type
+    remove_column :surveyor_dependency_conditions, :logic_reference
+  end
+end

--- a/spec/dummies/dummy5.1/db/schema.rb
+++ b/spec/dummies/dummy5.1/db/schema.rb
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 20170905204033) do
     t.text     "text_value"
     t.string   "string_value"
     t.string   "response_other"
+    t.string "condition_type", default: 'default'
+    t.string "logic_reference"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
   end

--- a/spec/dummies/dummy6.0/db/migrate/20220419032314_add_condition_type_fields_to_dependency_conditions.rb
+++ b/spec/dummies/dummy6.0/db/migrate/20220419032314_add_condition_type_fields_to_dependency_conditions.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+class AddConditionTypeFieldsToDependencyConditions < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column :surveyor_dependency_conditions, :condition_type, :string, default: 'default'
+    add_column :surveyor_dependency_conditions, :logic_reference, :string
+  end
+
+  def self.down
+    remove_column :surveyor_dependency_conditions, :condition_type
+    remove_column :surveyor_dependency_conditions, :logic_reference
+  end
+end

--- a/spec/dummies/dummy6.0/db/schema.rb
+++ b/spec/dummies/dummy6.0/db/schema.rb
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 2022_04_13_121950) do
     t.text "text_value"
     t.string "string_value"
     t.string "response_other"
+    t.string "condition_type", default: 'default'
+    t.string "logic_reference"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/dummies/dummy6.1/db/migrate/20220419031908_add_condition_type_fields_to_dependency_conditions.rb
+++ b/spec/dummies/dummy6.1/db/migrate/20220419031908_add_condition_type_fields_to_dependency_conditions.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+class AddConditionTypeFieldsToDependencyConditions < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :surveyor_dependency_conditions, :condition_type, :string, default: 'default'
+    add_column :surveyor_dependency_conditions, :logic_reference, :string
+  end
+
+  def self.down
+    remove_column :surveyor_dependency_conditions, :condition_type
+    remove_column :surveyor_dependency_conditions, :logic_reference
+  end
+end

--- a/spec/dummies/dummy6.1/db/schema.rb
+++ b/spec/dummies/dummy6.1/db/schema.rb
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 2022_04_13_065585) do
     t.text "text_value"
     t.string "string_value"
     t.string "response_other"
+    t.string "condition_type", default: 'default'
+    t.string "logic_reference"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/dummies/dummy7.0/db/migrate/20220419032157_add_condition_type_fields_to_dependency_conditions.rb
+++ b/spec/dummies/dummy7.0/db/migrate/20220419032157_add_condition_type_fields_to_dependency_conditions.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+class AddConditionTypeFieldsToDependencyConditions < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :surveyor_dependency_conditions, :condition_type, :string, default: 'default'
+    add_column :surveyor_dependency_conditions, :logic_reference, :string
+  end
+
+  def self.down
+    remove_column :surveyor_dependency_conditions, :condition_type
+    remove_column :surveyor_dependency_conditions, :logic_reference
+  end
+end

--- a/spec/dummies/dummy7.0/db/schema.rb
+++ b/spec/dummies/dummy7.0/db/schema.rb
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 2022_04_13_065585) do
     t.text "text_value"
     t.string "string_value"
     t.string "response_other"
+    t.string "condition_type", default: 'default'
+    t.string "logic_reference"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/fixtures/surveys/lifestyle.rb
+++ b/spec/fixtures/surveys/lifestyle.rb
@@ -19,6 +19,12 @@ survey "Lifestyle" do
     a_2 "integer"
     dependency :rule => "D"
     condition_D :q_copd_sh_1b, "==", :a_current_as_of_one_month
+
+    q_copd_sh_1cc "Do you think you'll be saved?"
+    a_0 "Yes"
+    a_1 "No"
+    dependency :rule => "A"
+    condition_A "religious", "==", { condition_type: 'logic', text_value: "true" }
   end
   section "Pets" do
     q_pets "How many pets do you own?"

--- a/spec/lib/surveyor/parser_spec.rb
+++ b/spec/lib/surveyor/parser_spec.rb
@@ -64,7 +64,7 @@ describe Surveyor::Parser do
     end
   end
 
-  context 'depdencies and validations' do
+  context 'dependencies and validations' do
     let(:file) { File.new(TEST_SURVEYS_PATH + '/lifestyle.rb') }
     subject! { Surveyor::Parser.new.parse(File.read(file)) }
 
@@ -72,20 +72,20 @@ describe Surveyor::Parser do
       expect(Surveyor::Survey.count).to eq(1)
       expect(Surveyor::SurveySection.count).to eq(2)
       expect(Surveyor::QuestionGroup.count).to eq(1)
-      expect(Surveyor::Question.count).to eq(10)
-      expect(Surveyor::Answer.count).to eq(12)
-      expect(Surveyor::Dependency.count).to eq(6)
-      expect(Surveyor::DependencyCondition.count).to eq(6)
+      expect(Surveyor::Question.count).to eq(11)
+      expect(Surveyor::Answer.count).to eq(14)
+      expect(Surveyor::Dependency.count).to eq(7)
+      expect(Surveyor::DependencyCondition.count).to eq(7)
       expect(Surveyor::Validation.count).to eq(2)
       expect(Surveyor::ValidationCondition.count).to eq(2)
-      depdendencies = [{ rule: 'B', question_reference_identifier: 'copd_sh_1b' },
+      dependencies = [{ rule: 'B', question_reference_identifier: 'copd_sh_1b' },
                        { rule: 'C', question_reference_identifier: 'copd_sh_1ba' },
                        { rule: 'D', question_reference_identifier: 'copd_sh_1bb' },
                        { rule: 'Q', question_group_reference_identifier: 'one_pet' },
                        { rule: 'R', question_reference_identifier: 'very_creative' },
                        { rule: 'S', question_reference_identifier: 'oh_my' }]
-      depdendencies.each { |attrs| (expect(Surveyor::Dependency.where(rule: attrs[:rule]).first.question.reference_identifier).to eq(attrs[:question_reference_identifier])) if attrs[:question_reference_identifier] }
-      depdendencies.each { |attrs| (expect(Surveyor::Dependency.where(rule: attrs[:rule]).first.question_group.reference_identifier).to eq(attrs[:question_group_reference_identifier])) if attrs[:question_group_reference_identifier] }
+      dependencies.each { |attrs| (expect(Surveyor::Dependency.where(rule: attrs[:rule]).first.question.reference_identifier).to eq(attrs[:question_reference_identifier])) if attrs[:question_reference_identifier] }
+      dependencies.each { |attrs| (expect(Surveyor::Dependency.where(rule: attrs[:rule]).first.question_group.reference_identifier).to eq(attrs[:question_group_reference_identifier])) if attrs[:question_group_reference_identifier] }
       dependency_conditions = [{ rule_key: 'B', question_reference_identifier: 'copd_sh_1', answer_reference_identifier: '1' },
                                { rule_key: 'C', question_reference_identifier: 'copd_sh_1b', answer_reference_identifier: 'quit' },
                                { rule_key: 'D', question_reference_identifier: 'copd_sh_1b', answer_reference_identifier: 'current_as_of_one_month' },


### PR DESCRIPTION
This pull request makes it possible to mix business logic with Surveyor, not being tied to the survey itself.

To achieve this, we've extended the `Surveyor::DependencyCondition` model with two extra fields:

- `condition_type` - "default" by default, but can be passed as logic to match any application-level logic
- `logic_reference` - The name of the logic variable to be associated with the dependency condition

Here's an example on how it can be used on the DSL:

```
  q_0 "Do you think you'll be saved?"
  a_0 "Yes"
  a_1 "No"
  dependency :rule => "A"
  condition_A "religious", "==", { condition_type: 'logic', text_value: "true" }
```

Where on the first parameter of `condition_A` we specify the `logic_reference`, on the second the operator (as usual) and then an hash stating the condition type and the value to be matched with.

On this example, the application would handle the value of "religious" on their dependency management code, only presenting this question to a user that fits in.