### PR TITLE
[Feature] Properly parse Validation Conditions

### DIFF
--- a/lib/surveyor/models/validation_condition_methods.rb
+++ b/lib/surveyor/models/validation_condition_methods.rb
@@ -11,7 +11,9 @@ module Surveyor
       included do
         # Associations
         belongs_to :validation
-        
+        belongs_to :question
+        belongs_to :answer
+
         if defined?(::ProtectedAttributes)
           attr_accessible(*PermittedParams.new.validation_condition_attributes)
         end

--- a/lib/surveyor/permitted_params.rb
+++ b/lib/surveyor/permitted_params.rb
@@ -82,7 +82,7 @@ module Surveyor
       strong_parameters.permit(*validation_condition_attributes)
     end
     def validation_condition_attributes
-      [:validation, :validation_id, :rule_key, :operator, :question_id, :answer_id, :datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :regexp]
+      [:validation, :validation_id, :rule_key, :operator, :question, :answer, :question_id, :answer_id, :datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :regexp, :question_reference, :answer_reference]
     end
 
     # response

--- a/lib/surveyor/version.rb
+++ b/lib/surveyor/version.rb
@@ -1,3 +1,3 @@
 module Surveyor
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
Validation Conditions were created not to only validate the format of a specific response, but also to validate it based on a question/answer combination.

Currently the parser was not mapping out the question/answer references, so we just replicated what was being done with the DependencyConditons.

So now we'll be able to create specific validations like the following:

```ruby
q_3 'Number of other people in the vehicle:',
    display_type: 'number_input',
    common_identifier: 'car_travel_party_size',
    is_mandatory: true
a_0 '&nbsp;'

q_4 'How many household members were with you?',
    display_type: 'number_input',
    common_identifier: 'hh_no_members',
    is_mandatory: true
dependency rule: 'A'
condition_A :q_3, '>', { text_value: "0", answer_reference: "0" }
a_0 '&nbsp;'
validation rule: 'A'
condition_A "<=", { question_reference: "3", answer_reference: "0" }
```

Where the second question will include a validation condition, where its value should be bigger or equal to the first question response value.